### PR TITLE
[FIX] Use modal-body for count steps instead of buttons

### DIFF
--- a/multi-step-modal.js
+++ b/multi-step-modal.js
@@ -5,8 +5,8 @@
 
     modals.each(function(idx, modal) {
         var $modal = $(modal);
-        var $buttons = $modal.find('button.step');
-        var total_num_steps = $buttons.length;
+        var $bodies = $modal.find('div.modal-body');
+        var total_num_steps = $bodies.length;
         var $progress = $modal.find('.m-progress');
         var $progress_bar = $modal.find('.m-progress-bar');
         var $progress_stats = $modal.find('.m-progress-stats');
@@ -106,7 +106,7 @@
             $progress_total.text(total_num_steps);
             bindEventsToModal($modal, total_num_steps);
             $modal.data({
-                total_num_steps: $buttons.length,
+                total_num_steps: $bodies.length,
             });
             if (reset_on_close){
                 //Bootstrap 2.3.2


### PR DESCRIPTION
If you use back and forward buttons, $buttons doubles the number of steps.