### PR TITLE
jQuery trigger fix (if used in a Google Chrome extension).

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,7 +141,8 @@
 <script src="multi-step-modal.js"></script>
 <script>
 sendEvent = function(sel, step) {
-    $(sel).trigger('next.m.' + step);
+    var sel_event = new CustomEvent('next.m.' + step, {detail: {step: step}});
+    window.dispatchEvent(sel_event);
 }
 </script>
 </body>

--- a/multi-step-modal.js
+++ b/multi-step-modal.js
@@ -92,9 +92,9 @@
             });
 
             $.each(data_steps, function(i, v) {
-                $modal.on('next.m.' + v, {step: v}, function(e) {
-                    goToStep(e.data.step);
-                });
+                window.addEventListener('next.m.' + v, function (evt) {
+                    goToStep(evt.detail.step);
+                }, false);
             });
         }
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "dependencies": {
+    "bootstrap": "^4.3.1",
+    "jquery": "^3.3.1"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ngzhian/multi-step-modal.git"

--- a/package.json
+++ b/package.json
@@ -18,11 +18,8 @@
     "multi",
     "step",
     "modal",
-    "modal",
     "bootstrap",
     "multistep",
-    "modal",
-    "bootstrap",
     "multi-step-modal"
   ],
   "author": "Ng Zhi An",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "multi-step-modal",
+  "version": "1.0.0",
+  "description": "A library to help you make multi-step modals, such as a multi-page registration form. It depends on bootstrap for the modal and jQuery for everything else.",
+  "main": "multi-step-modal.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ngzhian/multi-step-modal.git"
+  },
+  "keywords": [
+    "multi",
+    "step",
+    "modal",
+    "modal",
+    "bootstrap",
+    "multistep",
+    "modal",
+    "bootstrap",
+    "multi-step-modal"
+  ],
+  "author": "Ng Zhi An",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/ngzhian/multi-step-modal/issues"
+  },
+  "homepage": "https://github.com/ngzhian/multi-step-modal#readme"
+}


### PR DESCRIPTION
I have tried to use it in a Google chrome extension and after debugging I've seen that switching to JS Custom event would work on both cases.
If you consider this an improvement then you can merge this one, might be helpful, after you submit the node package.